### PR TITLE
Remove CustomEvent class in favour of subclassing Event

### DIFF
--- a/examples/dialogue/__main__.py
+++ b/examples/dialogue/__main__.py
@@ -5,7 +5,7 @@ from pygskin.assets import Assets
 from pygskin.dialogue import Dialogue
 from pygskin.dialogue import OptionSelected
 from pygskin.display import Display
-from pygskin.events import CustomEvent
+from pygskin.events import Event
 from pygskin.events import KeyDown
 from pygskin.events import MouseButtonDown
 from pygskin.events import MouseMotion
@@ -82,11 +82,11 @@ class Game(Window):
         self.dialogue.update()
 
 
-class MouseEnter(CustomEvent):
+class MouseEnter(Event):
     pass
 
 
-class MouseExit(CustomEvent):
+class MouseExit(Event):
     pass
 
 

--- a/pygskin/dialogue.py
+++ b/pygskin/dialogue.py
@@ -9,7 +9,7 @@ from typing import Any
 from typing import TypedDict
 
 from pygskin.clock import Timer
-from pygskin.events import CustomEvent
+from pygskin.events import Event
 from pygskin.events import event_listener
 from pygskin.pubsub import message
 from pygskin.statemachine import StateMachine
@@ -241,7 +241,7 @@ class NextState(Action):
 Option = TypedDict("Option", {"value": str, "text": str, "if": str})
 
 
-class OptionSelected(CustomEvent):
+class OptionSelected(Event):
     pass
 
 

--- a/pygskin/events.py
+++ b/pygskin/events.py
@@ -48,9 +48,11 @@ class Event:
         self.cancelled = False
 
     def __init_subclass__(cls, **kwargs) -> None:
-        if event_type := kwargs.get("event_type"):
-            cls.event_type = int(event_type)
-            Event.TYPE_MAP[cls.event_type] = cls
+        _type = kwargs.get("event_type")
+
+        cls.event_type = int(_type) if _type is not None else pygame.event.custom_type()
+
+        Event.TYPE_MAP[cls.event_type] = cls
 
     @classmethod
     def build(cls, event: pygame.event.Event) -> Event | None:
@@ -128,12 +130,6 @@ class MouseMotion(Event, event_type=pygame.MOUSEMOTION):
 
 class Quit(Event, event_type=pygame.QUIT):
     pass
-
-
-class CustomEvent(Event):
-    def __init_subclass__(cls, **kwargs) -> None:
-        cls.event_type = pygame.event.custom_type()
-        super().__init_subclass__(event_type=cls.event_type)
 
 
 class EventListener(Decorator):


### PR DESCRIPTION
* Feels more natural to create a custom event class by subclassing Event

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated event handling by renaming and reorganizing event classes for clarity and consistency.
  
- **Bug Fixes**
  - Ensured all event-related classes now correctly inherit from the base `Event` class.

- **Documentation**
  - Adjusted documentation to reflect changes in event class names and inheritance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->