### PR TITLE
Fix issue with widget IDs in loop

### DIFF
--- a/pygskin/imgui.py
+++ b/pygskin/imgui.py
@@ -136,7 +136,7 @@ def get_renderer(ui: IMGUI, surface: pygame.Surface, get_styles=None):
 
     def render_fn(widget: Widget, **style) -> Widget:
         frame_info = inspect.stack()[1]
-        widget_id = hash((frame_info.filename, frame_info.lineno))
+        widget_id = hash((frame_info.filename, frame_info.lineno, widget.value))
         if callable(get_styles):
             style = get_styles(widget) | style
         with _get_widget(ui, widget_id, widget, **style) as _widget:


### PR DESCRIPTION
* Widget id is derived from source file and line number, but this means widgets defined in a loop will share an ID. Same for widgets defined in a function.
* This fix includes widget value in ID hash. But this still is not enough for multiple widgets with the same value. Is this a problem?
* TODO Maybe hash widget position + size? Does it matter if occluded widgets have the same ID as long as we can only interact with the uppermost?